### PR TITLE
Clone legacy branch

### DIFF
--- a/dev/build.sh
+++ b/dev/build.sh
@@ -32,12 +32,13 @@ popd
 
 # Build LoRa gateway app for this specific platform
 if [ ! -d lora_gateway ]; then
-    git clone https://github.com/TheThingsNetwork/lora_gateway.git
+    git clone -b legacy https://github.com/TheThingsNetwork/lora_gateway.git
     pushd lora_gateway
 else
     pushd lora_gateway
+    git fetch origin
+    git checkout legacy
     git reset --hard
-    git pull
 fi
 sed -i -e 's/PLATFORM= kerlink/PLATFORM= imst_rpi/g' ./libloragw/library.cfg
 # Comment the following in or out as needed for hardware debugging
@@ -51,11 +52,12 @@ popd
 
 # Build the packet forwarder
 if [ ! -d packet_forwarder ]; then
-    git clone https://github.com/TheThingsNetwork/packet_forwarder.git
+    git clone -b legacy https://github.com/TheThingsNetwork/packet_forwarder.git
     pushd packet_forwarder
 else
     pushd packet_forwarder
-    git pull
+    git fetch origin
+    git checkout legacy
     git reset --hard
 fi
 make


### PR DESCRIPTION
We have moved the old Semtech UDP based packet forwarder to the `legacy` branch. This is the default branch, so cloning is still fine, but pulling from `master` will fail.

This PR clones from `legacy` and checks out `legacy` when the folder exists.